### PR TITLE
Added details about how tc is located

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,9 +345,9 @@ pumba netem --duration 5m corrupt --percent 10 mydb
 
 ##### `tc` tool
 
-Pumba uses `tc` Linux tool for network emulation. You have two options:
+Pumba uses the `tc` Linux tool for network emulation. You have two options:
 
-1. Make sure that container, you want to disturb, has `tc` tool available and properly installed (install `iproute2` package)
+1. Make sure that the container you want to disturb has the `tc` tool installed. Pumba checks for this by running `which tc` inside the container, so both `which` and `tc` need to be installed. They are typically found in the `which` and `iproute2` packages, respectively.
 2. Use `--tc-image` option, with any `netem` command, to specify external Docker image with `tc` tool available. Pumba will create a new container from this image, adding `NET_ADMIN` capability to it and reusing target container network stack. You can try to use [gaiadocker/iproute2](https://hub.docker.com/r/gaiadocker/iproute2/) image (it's just Alpine Linux 3.3 with `iproute2` package installed)
 
 **Note:** For Alpine Linux based image, you need to install `iproute2` package and also to create a symlink pointing to distribution files `ln -s /usr/lib/tc /lib/tc`.


### PR DESCRIPTION
Some docker images are so minimal, they don't even ship with `which`. Since netem checks for the presencs of `tc` by using `which` regarding any exit code other than 0 as indication that `tc` does not exist, pumba will incorrectly report `tc` as missing even though it may be installed.
The readme now contains an explanation of how exactly this lookup process is done to save future users some confusion.